### PR TITLE
Fix for when maxInstancedCount is 0 at WebGLRenderer

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -901,9 +901,10 @@ THREE.WebGLRenderer = function ( parameters ) {
 
 		}
 
-		if ( geometry instanceof THREE.InstancedBufferGeometry && geometry.maxInstancedCount > 0 ) {
-
-			renderer.renderInstances( geometry, drawStart, drawCount );
+		if ( geometry instanceof THREE.InstancedBufferGeometry ) {
+			if( geometry.maxInstancedCount > 0 ) {
+				renderer.renderInstances( geometry, drawStart, drawCount );
+			}
 
 		} else {
 


### PR DESCRIPTION
When geometry.maxInstancedCount is set to 0, an instance is still rendered.

You can see in this example. A triangle is rendered when maxInstancedCount is set to 0
http://threejs.org/examples/#webgl_buffergeometry_instancing
